### PR TITLE
Rename hard_restack to unsafe_restack (and also un-export it)

### DIFF
--- a/src/Restacker.jl
+++ b/src/Restacker.jl
@@ -1,6 +1,6 @@
 module Restacker
 
-export restack, hard_restack
+export restack
 
 """
     restack(x) -> x
@@ -13,13 +13,13 @@ restack
 restack(x) = _restack(x, Val(false))
 
 """
-    hard_restack(x) -> x
+    unsafe_restack(x) -> x
 
 Like `restack(x)` but works for mutable objects, too. Thus, this is
 the identity function only w.r.t (at most) `isequal`.
 """
-hard_restack
-hard_restack(x) = _restack(x, Val(true))
+unsafe_restack
+unsafe_restack(x) = _restack(x, Val(true))
 
 _getlength(::Type{<:NTuple{N,Any}}) where {N} = N
 _getnames(::Type{<:NamedTuple{names}}) where {names} = names

--- a/test/test_core.jl
+++ b/test/test_core.jl
@@ -1,7 +1,7 @@
 module TestCore
 
 using Test
-using Restacker: restack, hard_restack
+using Restacker: restack, unsafe_restack
 
 struct ABC{A,B,C}
     a::A
@@ -39,7 +39,7 @@ end
     ),
 ]
     @test restack(x) === x
-    @test hard_restack(x) === x
+    @test unsafe_restack(x) === x
 end
 
 @testset "$(testlabel(x))" for x in Any[
@@ -50,9 +50,9 @@ end
     (a = Dict(:a => 1, :b => 2), b = Set([1, 2]), c = ABC(1, 2, 3)),
 ]
     if (x == x) === true
-        @test hard_restack(x) == x
+        @test unsafe_restack(x) == x
     end
-    @test isequal(hard_restack(x), x)
+    @test isequal(unsafe_restack(x), x)
 end
 
 end  # module


### PR DESCRIPTION
as it's unsafe when `finalizer` is used (e.g., `PyObject`).