### PR TITLE
Fix .mergify.yml; don't merge when a test failed

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -9,6 +9,7 @@ pull_request_rules:
       - base=master
       - "#approved-reviews-by>=1"
       - status-success~=Test Julia .*
+      - -status-failure~=Test Julia [0-9].*
       - status-success=Benchmark
       - label=ready-to-merge:squash
       - label!=work-in-progress
@@ -20,6 +21,7 @@ pull_request_rules:
       - base=master
       - "#approved-reviews-by>=1"
       - status-success~=Test Julia .*
+      - -status-failure~=Test Julia [0-9].*
       - status-success=Benchmark
       - label=ready-to-merge:rebase
       - label!=work-in-progress
@@ -31,6 +33,7 @@ pull_request_rules:
       - base=master
       - "#approved-reviews-by>=1"
       - status-success~=Test Julia .*
+      - -status-failure~=Test Julia [0-9].*
       - status-success=Benchmark
       - label=ready-to-merge:merge
       - label!=work-in-progress
@@ -42,6 +45,7 @@ pull_request_rules:
       - author=tkf
       - base=master
       - status-success~=Test Julia .*
+      - -status-failure~=Test Julia [0-9].*
       - status-success=Benchmark
       - label~=ready-to-merge:.*
     actions:


### PR DESCRIPTION
The previous setting was not working.  PR #7 was merged even though the test with Julia 1.0 failed.
